### PR TITLE
test: do not mkdir with basedir / on Windows

### DIFF
--- a/test/temp_test.exs
+++ b/test/temp_test.exs
@@ -75,8 +75,11 @@ defmodule TempTest do
     assert String.starts_with?(Path.basename(dir), "abc")
     File.rmdir!(dir)
 
-    {err, _} = Temp.mkdir %{basedir: "/"}
-    assert err == :error
+    {osfamily, _} = :os.type
+    unless osfamily == :win32 do
+      {err, _} = Temp.mkdir %{basedir: "/"}
+      assert err == :error
+    end
   end
 
   test :track do


### PR DESCRIPTION
it actually succeeds and creates extra
directories on Windows
