### PR TITLE
Added a file extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ end
 {:ok, tmp_path} = Temp.path "my-prefix"
 # with prefix and suffix
 {:ok, tmp_path} = Temp.path %{prefix: "my-prefix", suffix: "my-suffix"}
+# with prefix and suffix and file extension
+{:ok, tmp_path} = Temp.path %{prefix: "my-prefix", suffix: "my-suffix", extension: "temp"}
 # in a non-default tmp_dir
 {:ok, tmp_path} = Temp.path %{prefix: "my-prefix", suffix: "my-suffix", basedir: "/my-tmp"}
 # error on fail

--- a/lib/temp.ex
+++ b/lib/temp.ex
@@ -170,6 +170,12 @@ defmodule Temp do
           else
             parts
           end
+        parts =
+          if affixes[:extension] do
+            parts ++ [".", affixes[:extension]]
+          else
+            parts
+          end
         name = Path.join(path, Enum.join(parts))
         {:ok, name, affixes}
       err -> err
@@ -187,14 +193,15 @@ defmodule Temp do
 
   @spec parse_affixes(options, Path.t) :: map
   defp parse_affixes(nil, default_prefix), do: %{prefix: default_prefix}
-  defp parse_affixes(affixes, _) when is_bitstring(affixes), do: %{prefix: affixes, suffix: nil}
+  defp parse_affixes(affixes, _) when is_bitstring(affixes), do: %{prefix: affixes, suffix: nil, extension: nil}
   defp parse_affixes(affixes, default_prefix) when is_map(affixes) do
     affixes
     |> Dict.put(:prefix, affixes[:prefix] || default_prefix)
     |> Dict.put(:suffix, affixes[:suffix] || nil)
+    |> Dict.put(:extension, affixes[:extension] || nil)
   end
   defp parse_affixes(_, default_prefix) do
-    %{prefix: default_prefix, suffix: nil}
+    %{prefix: default_prefix, suffix: nil, extension: nil}
   end
 
   defp get_tracker do

--- a/test/temp_test.exs
+++ b/test/temp_test.exs
@@ -16,12 +16,18 @@ defmodule TempTest do
 
     path = Temp.path! %{basedir: "bar", prefix: "my-prefix"}
     assert Path.dirname(path) == "bar"
-    assert String.starts_with?(Path.basename(path), "my-prefix")
+    assert String.starts_with?(Path.basename(path), "my-prefix-")
 
     path = Temp.path! %{basedir: "other", prefix: "my-prefix", suffix: "my-suffix"}
     assert Path.dirname(path) == "other"
-    assert String.starts_with?(Path.basename(path), "my-prefix")
-    assert String.ends_with?(Path.basename(path), "my-suffix")
+    assert String.starts_with?(Path.basename(path), "my-prefix-")
+    assert String.ends_with?(Path.basename(path), "-my-suffix")
+
+    path = Temp.path! %{basedir: "baz", prefix: "my-prefix", suffix: "my-suffix",
+      extension: "txt"}
+    assert Path.dirname(path) == "baz"
+    assert String.starts_with?(Path.basename(path), "my-prefix-")
+    assert String.ends_with?(Path.basename(path), "-my-suffix.txt")
   end
 
   test :open do


### PR DESCRIPTION
Hi to all
I've added file extension support as separate option.

```
iex(2)> {:ok, tmp_path} = Temp.path %{prefix: "test", extension: "temp"}
{:ok,
 "/var/folders/sz/ngg02bwj2ndfp1yk1m6z4ctm0000gn/T/test-1476338148-51199-b8r6bg.temp"}
```

Also added a dash checking in prefix/suffix tests
