### PR TITLE
Fix path! return value and typing

### DIFF
--- a/lib/temp.ex
+++ b/lib/temp.ex
@@ -80,11 +80,11 @@ defmodule Temp do
   @doc """
   Same as `path/1`, but raises an exception on failure. Otherwise, returns a temporary path.
   """
-  @spec path!(options) :: Path.t
+  @spec path!(options) :: Path.t | no_return
   def path!(options \\ nil) do
     case path(options) do
       {:ok, path} -> path
-      err -> err
+      err         -> raise Temp.Error, message: err
     end
   end
 


### PR DESCRIPTION
Currently `path!` can return `Path.t` or `{:error, term}`
I suppose it should raise an exception instead