### PR TITLE
Fix "Enum.partition/2 is deprecated" warning in Elixir 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: elixir
-elixir:
-  - 1.0.5
-  - 1.1.1
-  - 1.2.2
-otp_release:
-  - 17.5
-  - 18.0
+
+matrix:
+  include:
+    - elixir: 1.0.5
+      otp_release: 17.5
+    - elixir: 1.1.1
+      otp_release: 18.0
+    - elixir: 1.2.2
+      otp_release: 18.3
+    - elixir: 1.3.4
+      otp_release: 19.2
+    - elixir: 1.4.5
+      otp_release: 19.2
+    - elixir: 1.5.3
+      otp_release: 20.3
+    - elixir: 1.6.4
+      otp_release: 20.3

--- a/lib/temp/tracker.ex
+++ b/lib/temp/tracker.ex
@@ -33,11 +33,14 @@ defmodule Temp.Tracker do
   end
 
   defp cleanup(state) do
-    Enum.partition state, fn path ->
-      case File.rm_rf(path) do
-        {:ok, _} -> true
-        _ -> false
-      end
-    end
+    {removed, failed} =
+      state
+      |> Enum.reduce({[], []}, fn path, {removed, failed} ->
+        case File.rm_rf(path) do
+          {:ok, _} -> {[path | removed], failed}
+          _ -> {removed, [path | failed]}
+        end
+      end)
+    {:lists.reverse(removed), :lists.reverse(failed)}
   end
 end


### PR DESCRIPTION
I have changed this method from Enum.partition to Enum.reduce.
I would simply change Enum.partition to Enum.split_with but did not want to break compatibility with older versions specified in your .travis.yml because split_with does not exist in Elixir <= 1.4
I have also added newer Elixirs to Travis matrix