### PR TITLE
passing directories between trackers and extra tests

### DIFF
--- a/lib/temp.ex
+++ b/lib/temp.ex
@@ -1,5 +1,5 @@
 defmodule Temp do
-  @type options :: nil | Path.t | map
+  @type options :: nil | Path.t() | map
 
   @doc """
   Returns `:ok` when the tracking server used to track temporary files started properly.
@@ -7,11 +7,12 @@ defmodule Temp do
 
   @pdict_key :"$__temp_tracker__"
 
-  @spec track :: Agent.on_start
+  @spec track :: Agent.on_start()
   def track() do
     case Process.get(@pdict_key) do
       nil ->
         start_tracker()
+
       v ->
         {:ok, v}
     end
@@ -22,6 +23,7 @@ defmodule Temp do
       {:ok, pid} ->
         Process.put(@pdict_key, pid)
         {:ok, pid}
+
       err ->
         err
     end
@@ -41,16 +43,15 @@ defmodule Temp do
   @doc """
   Return the paths currently tracked.
   """
-  @spec tracked :: Set.t
+  @spec tracked :: Set.t()
   def tracked(tracker \\ get_tracker!()) do
     GenServer.call(tracker, :tracked)
   end
 
-
   @doc """
   Cleans up the temporary files tracked.
   """
-  @spec cleanup(pid, Keyword.t) :: [Path.t]
+  @spec cleanup(pid, Keyword.t()) :: [Path.t()]
   def cleanup(tracker \\ get_tracker!(), opts \\ []) do
     GenServer.call(tracker, :cleanup, opts[:timeout] || :infinity)
   end
@@ -75,7 +76,7 @@ defmodule Temp do
     * `:basedir` - places the generated file in the designated base directory
       instead of the system temporary directory
   """
-  @spec path(options) :: {:ok, Path.t} | {:error, String.t}
+  @spec path(options) :: {:ok, Path.t()} | {:error, String.t()}
   def path(options \\ nil) do
     case generate_name(options, "f") do
       {:ok, path, _} -> {:ok, path}
@@ -86,7 +87,7 @@ defmodule Temp do
   @doc """
   Same as `path/1`, but raises an exception on failure. Otherwise, returns a temporary path.
   """
-  @spec path!(options) :: Path.t | no_return
+  @spec path!(options) :: Path.t() | no_return
   def path!(options \\ nil) do
     case path(options) do
       {:ok, path} -> path
@@ -107,30 +108,38 @@ defmodule Temp do
 
   See `path/1`.
   """
-  @spec open(options, nil | (File.io_device -> any)) :: {:ok, Path.t} | {:ok, File.io_device, Path.t} | {:error, any}
+  @spec open(options, nil | (File.io_device() -> any)) ::
+          {:ok, Path.t()} | {:ok, File.io_device(), Path.t()} | {:error, any}
   def open(options \\ nil, func \\ nil) do
     case generate_name(options, "f") do
       {:ok, path, options} ->
         options = Map.put(options, :mode, options[:mode] || [:read, :write])
-        ret = if func do
-          File.open(path, options[:mode], func)
-        else
-          File.open(path, options[:mode])
-        end
+
+        ret =
+          if func do
+            File.open(path, options[:mode], func)
+          else
+            File.open(path, options[:mode])
+          end
+
         case ret do
           {:ok, res} ->
             if tracker = get_tracker(), do: register_path(tracker, path)
             if func, do: {:ok, path}, else: {:ok, res, path}
-          err -> err
+
+          err ->
+            err
         end
-      err -> err
+
+      err ->
+        err
     end
   end
 
   @doc """
   Add a file to the tracker, so that it will be removed automatically or on Temp.cleanup.
   """
-  @spec track_file(any) :: {:error, :tracker_not_found} | {:ok, Path.t}
+  @spec track_file(any) :: {:error, :tracker_not_found} | {:ok, Path.t()}
   def track_file(path, tracker \\ get_tracker()) do
     case is_nil(tracker) do
       true -> {:error, :tracker_not_found}
@@ -141,7 +150,7 @@ defmodule Temp do
   @doc """
   Same as `open/1`, but raises an exception on failure.
   """
-  @spec open!(options, pid | nil) :: Path.t | {File.io_device, Path.t} | no_return
+  @spec open!(options, pid | nil) :: Path.t() | {File.io_device(), Path.t()} | no_return
   def open!(options \\ nil, func \\ nil) do
     case open(options, func) do
       {:ok, res, path} -> {res, path}
@@ -149,7 +158,6 @@ defmodule Temp do
       {:error, err} -> raise Temp.Error, message: err
     end
   end
-
 
   @doc """
   Returns `{:ok, dir_path}` where `dir_path` is the path is the path of the
@@ -162,17 +170,21 @@ defmodule Temp do
 
   See `path/1`.
   """
-  @spec mkdir(options) :: {:ok, Path.t} | {:error, any}
+  @spec mkdir(options) :: {:ok, Path.t()} | {:error, any}
   def mkdir(options \\ %{}) do
     case generate_name(options, "d") do
       {:ok, path, _} ->
-        case File.mkdir path do
+        case File.mkdir(path) do
           :ok ->
             if tracker = get_tracker(), do: register_path(tracker, path)
             {:ok, path}
-          err -> err
+
+          err ->
+            err
         end
-      err -> err
+
+      err ->
+        err
     end
   end
 
@@ -180,47 +192,96 @@ defmodule Temp do
   Same as `mkdir/1`, but raises an exception on failure. Otherwise, returns
   a temporary directory path.
   """
-  @spec mkdir!(options) :: Path.t | no_return
+  @spec mkdir!(options) :: Path.t() | no_return
   def mkdir!(options \\ %{}) do
     case mkdir(options) do
       {:ok, path} ->
         if tracker = get_tracker(), do: register_path(tracker, path)
         path
-      {:error, err} -> raise Temp.Error, message: err
+
+      {:error, err} ->
+        raise Temp.Error, message: err
     end
   end
 
-  @spec generate_name(options, Path.t) :: {:ok, Path.t, map | Keyword.t} | {:error, String.t}
-  defp generate_name(options, default_prefix)
-  defp generate_name(options, default_prefix) when is_list(options) do
-    generate_name(Enum.into(options,%{}), default_prefix)
+  @doc """
+  Removes all passed paths from the tracker for the current processes,
+  and gives them to the tracker at heir_pid.
+  Returns `:ok` if successful.
+  Returns `{:error, reason}` if a failure occurs.
+  """
+  @spec handoff(Path.t() | [Path.t()], pid()) :: :ok | {:error, String.t()}
+  def handoff(paths, heir_pid, tracker \\ get_tracker()) do
+    case tracker do
+      nil ->
+        {:error, "no tracker"}
+
+      tracker_pid ->
+        if Process.alive?(heir_pid) do
+          paths =
+            if !is_list(paths) do
+              [paths]
+            else
+              paths
+            end
+
+          GenServer.call(tracker_pid, {:handoff, paths, heir_pid})
+        else
+          {:error, "dead heir pid"}
+        end
+    end
   end
+
+  @doc """
+  Same as `handoff/3`, but raises an exception on failure. Otherwise, returns `:ok`.
+  """
+  @spec handoff!(Path.t() | [Path.t()], pid()) :: :ok | no_return()
+  def handoff!(paths, heir_pid, tracker \\ get_tracker()) do
+    case handoff(paths, heir_pid, tracker) do
+      {:error, reason} -> raise Temp.Error, message: reason
+      :ok -> :ok
+    end
+  end
+
+  @spec generate_name(options, Path.t()) ::
+          {:ok, Path.t(), map | Keyword.t()} | {:error, String.t()}
+  defp generate_name(options, default_prefix)
+
+  defp generate_name(options, default_prefix) when is_list(options) do
+    generate_name(Enum.into(options, %{}), default_prefix)
+  end
+
   defp generate_name(options, default_prefix) do
     case prefix(options) do
       {:ok, path} ->
         affixes = parse_affixes(options, default_prefix)
         parts = [timestamp(), "-", :os.getpid(), "-", random_string()]
+
         parts =
           if affixes[:prefix] do
             [affixes[:prefix], "-"] ++ parts
           else
             parts
           end
+
         parts = add_suffix(parts, affixes[:suffix])
         name = Path.join(path, Enum.join(parts))
         {:ok, name, affixes}
-      err -> err
+
+      err ->
+        err
     end
   end
 
   defp add_suffix(parts, suffix)
   defp add_suffix(parts, nil), do: parts
-  defp add_suffix(parts, ("." <> _suffix) = suffix), do: parts ++ [suffix]
+  defp add_suffix(parts, "." <> _suffix = suffix), do: parts ++ [suffix]
   defp add_suffix(parts, suffix), do: parts ++ ["-", suffix]
 
   defp prefix(%{basedir: dir}), do: {:ok, dir}
+
   defp prefix(_) do
-    case System.tmp_dir do
+    case System.tmp_dir() do
       nil -> {:error, "no tmp_dir readable"}
       path -> {:ok, path}
     end
@@ -228,11 +289,13 @@ defmodule Temp do
 
   defp parse_affixes(nil, default_prefix), do: %{prefix: default_prefix}
   defp parse_affixes(affixes, _) when is_bitstring(affixes), do: %{prefix: affixes, suffix: nil}
+
   defp parse_affixes(affixes, default_prefix) when is_map(affixes) do
     affixes
     |> Map.put(:prefix, affixes[:prefix] || default_prefix)
     |> Map.put(:suffix, affixes[:suffix] || nil)
   end
+
   defp parse_affixes(_, default_prefix) do
     %{prefix: default_prefix, suffix: nil}
   end
@@ -245,6 +308,7 @@ defmodule Temp do
     case get_tracker() do
       nil ->
         raise Temp.Error, message: "temp tracker not started"
+
       pid ->
         pid
     end
@@ -255,12 +319,12 @@ defmodule Temp do
   end
 
   defp timestamp do
-    {ms, s, _} = :os.timestamp
+    {ms, s, _} = :os.timestamp()
     Integer.to_string(ms * 1_000_000 + s)
   end
 
   defp random_string do
-    Integer.to_string(rand_uniform(0x100000000), 36) |> String.downcase
+    Integer.to_string(rand_uniform(0x100000000), 36) |> String.downcase()
   end
 
   if :erlang.system_info(:otp_release) >= '18' do

--- a/lib/temp/tracker.ex
+++ b/lib/temp/tracker.ex
@@ -3,16 +3,16 @@ defmodule Temp.Tracker do
   @type state :: MapSet.t() | HashSet.t()
 
   if :application.get_key(:elixir, :vsn) |> elem(1) |> to_string() |> Version.match?("~> 1.1") do
-    defp set(), do: MapSet.new()
-    defp set(list), do: MapSet.new(list)
+    def set(), do: MapSet.new()
+    def set(list), do: MapSet.new(list)
     defdelegate union(set1, set2), to: MapSet
     defdelegate put(set, value), to: MapSet
     defdelegate difference(set1, set2), to: MapSet
     defdelegate intersection(set1, set2), to: MapSet
   else
-    defp set(), do: HashSet.new()
+    def set(), do: HashSet.new()
 
-    defp set(list) do
+    def set(list) do
       set_helper(list, set())
     end
 

--- a/lib/temp/tracker.ex
+++ b/lib/temp/tracker.ex
@@ -28,7 +28,7 @@ defmodule Temp.Tracker do
     defdelegate intersection(set1, set2), to: HashSet
   end
 
-  @spec start_link(nil) :: GenServer.on_start()
+  @spec start_link(any()) :: GenServer.on_start()
   def start_link(_) do
     GenServer.start_link(__MODULE__, nil)
   end

--- a/lib/temp/tracker.ex
+++ b/lib/temp/tracker.ex
@@ -28,9 +28,9 @@ defmodule Temp.Tracker do
     defdelegate intersection(set1, set2), to: HashSet
   end
 
-  @spec start_link(pid()) :: GenServer.on_start()
-  def start_link(tracked_pid) do
-    GenServer.start_link(__MODULE__, tracked_pid)
+  @spec start_link(nil) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, nil)
   end
 
   @spec init(any()) :: {:ok, state()}

--- a/lib/temp/tracker.ex
+++ b/lib/temp/tracker.ex
@@ -1,21 +1,50 @@
 defmodule Temp.Tracker do
   use GenServer
+  @type state :: MapSet.t() | HashSet.t()
 
   if :application.get_key(:elixir, :vsn) |> elem(1) |> to_string() |> Version.match?("~> 1.1") do
-    defp set(), do: MapSet.new
+    defp set(), do: MapSet.new()
+    defp set(list), do: MapSet.new(list)
+    defdelegate union(set1, set2), to: MapSet
     defdelegate put(set, value), to: MapSet
+    defdelegate difference(set1, set2), to: MapSet
+    defdelegate intersection(set1, set2), to: MapSet
   else
-    defp set(), do: HashSet.new
+    defp set(), do: HashSet.new()
+
+    defp set(list) do
+      set_helper(list, set())
+    end
+
+    defp set_helper([], cur_set), do: cur_set
+
+    defp set_helper([head | tail], cur_set) do
+      set_helper(tail, put(cur_set, head))
+    end
+
+    defdelegate union(set1, set2), to: HashSet
     defdelegate put(set, value), to: HashSet
+    defdelegate difference(set1, set2), to: HashSet
+    defdelegate intersection(set1, set2), to: HashSet
   end
 
-  def init(_args) do
+  @spec start_link(pid()) :: GenServer.on_start()
+  def start_link(tracked_pid) do
+    GenServer.start_link(__MODULE__, tracked_pid)
+  end
+
+  @spec init(any()) :: {:ok, state()}
+  def init(_) do
     Process.flag(:trap_exit, true)
     {:ok, set()}
   end
 
   def handle_call({:add, item}, _from, state) do
     {:reply, item, put(state, item)}
+  end
+
+  def handle_call({:receive, passed_over_set}, _from, state) do
+    {:reply, :ok, union(passed_over_set, state)}
   end
 
   def handle_call(:tracked, _from, state) do
@@ -25,6 +54,14 @@ defmodule Temp.Tracker do
   def handle_call(:cleanup, _from, state) do
     {removed, failed} = cleanup(state)
     {:reply, removed, Enum.into(failed, set())}
+  end
+
+  def handle_call({:handoff, paths, heir_pid}, _from, state) do
+    paths_set = set(paths)
+    new_state = difference(state, paths_set)
+    passed_over_set = intersection(state, paths_set)
+    GenServer.call(heir_pid, {:receive, passed_over_set})
+    {:reply, :ok, new_state}
   end
 
   def terminate(_reason, state) do
@@ -41,6 +78,7 @@ defmodule Temp.Tracker do
           _ -> {removed, [path | failed]}
         end
       end)
+
     {:lists.reverse(removed), :lists.reverse(failed)}
   end
 end

--- a/test/temp_test.exs
+++ b/test/temp_test.exs
@@ -2,14 +2,14 @@ defmodule TempTest do
   use ExUnit.Case
 
   test :path do
-    {:ok, path} = Temp.path
+    {:ok, path} = Temp.path()
     assert File.exists?(Path.dirname(path))
     assert String.starts_with?(Path.basename(path), "f-")
     refute String.ends_with?(Path.basename(path), "-")
 
-    path = Temp.path!
+    path = Temp.path!()
     assert File.exists?(Path.dirname(path))
-    assert path != Temp.path!
+    assert path != Temp.path!()
 
     path = Temp.path!(basedir: "foo")
     assert Path.dirname(path) == "foo"
@@ -29,7 +29,7 @@ defmodule TempTest do
   end
 
   test :open do
-    {:ok, file, path} = Temp.open
+    {:ok, file, path} = Temp.open()
     assert File.exists?(path)
     assert String.starts_with?(Path.basename(path), "f-")
     refute String.ends_with?(Path.basename(path), "-")
@@ -48,7 +48,7 @@ defmodule TempTest do
   end
 
   test :open! do
-    {file, path} = Temp.open!
+    {file, path} = Temp.open!()
     assert File.exists?(path)
     assert String.starts_with?(Path.basename(path), "f-")
     refute String.ends_with?(Path.basename(path), "-")
@@ -63,12 +63,12 @@ defmodule TempTest do
     File.rm!(path)
 
     assert_raise Temp.Error, fn ->
-      Temp.open! %{basedir: "/"}
+      Temp.open!(%{basedir: "/"})
     end
   end
 
   test :mkdir do
-    {:ok, dir} = Temp.mkdir
+    {:ok, dir} = Temp.mkdir()
     assert File.exists?(dir)
     assert String.starts_with?(Path.basename(dir), "d-")
     refute String.ends_with?(Path.basename(dir), "-")
@@ -79,7 +79,8 @@ defmodule TempTest do
     assert String.starts_with?(Path.basename(dir), "abc")
     File.rmdir!(dir)
 
-    {osfamily, _} = :os.type
+    {osfamily, _} = :os.type()
+
     unless osfamily == :win32 do
       {err, _} = Temp.mkdir(basedir: "/")
       assert err == :error
@@ -87,42 +88,46 @@ defmodule TempTest do
   end
 
   test :track do
-    assert {:ok, tracker} = Temp.track
+    assert {:ok, tracker} = Temp.track()
     {:ok, dir} = Temp.mkdir(nil)
     assert File.exists?(dir)
 
     {:ok, path} = Temp.open("bar", &IO.write(&1, "foobar"))
     assert File.exists?(path)
 
-    assert Enum.count(Temp.tracked) == 2
+    assert Enum.count(Temp.tracked()) == 2
 
     parent = self()
-    spawn_link fn ->
-      send parent, {:count, Temp.tracked(tracker) |> Enum.count}
-    end
+
+    spawn_link(fn ->
+      send(parent, {:count, Temp.tracked(tracker) |> Enum.count()})
+    end)
+
     assert_receive {:count, 2}
 
-    assert Enum.count(Temp.cleanup) == 2
+    assert Enum.count(Temp.cleanup()) == 2
     refute File.exists?(dir)
     refute File.exists?(path)
-    assert Enum.count(Temp.tracked) == 0
+    assert Enum.count(Temp.tracked()) == 0
 
     # check cleanup can be called multiple times safely
-    {:ok, dir} = Temp.mkdir nil
+    {:ok, dir} = Temp.mkdir(nil)
     assert File.exists?(dir)
-    assert Enum.count(Temp.cleanup) == 1
+    assert Enum.count(Temp.cleanup()) == 1
     refute File.exists?(dir)
 
     {:ok, dir} = Temp.mkdir(nil)
-    spawn_link fn ->
-      send(parent, {:cleaned, Temp.cleanup(tracker) |> Enum.count})
-    end
+
+    spawn_link(fn ->
+      send(parent, {:cleaned, Temp.cleanup(tracker) |> Enum.count()})
+    end)
+
     assert_receive {:cleaned, 1}
     refute File.exists?(dir)
   end
 
   test :track_file do
-    assert {:ok, tracker} = Temp.track
+    assert {:ok, tracker} = Temp.track()
 
     path_of_tmp_file = "test/tmp_file_created_by_programmer"
     File.write!(path_of_tmp_file, "Make Elixir Gr8 Again")
@@ -134,5 +139,66 @@ defmodule TempTest do
     Temp.cleanup(tracker)
 
     refute File.exists?(path_of_tmp_file)
+  end
+
+  test :handoff do
+    Temp.mkdir!()
+
+    heir_pid = Temp.track!()
+
+    path_of_tmp_file =
+      Task.async(fn ->
+        Temp.track!()
+        dir = Temp.mkdir!()
+        Temp.handoff(dir, heir_pid)
+        dir
+      end)
+      |> Task.await()
+
+    assert Temp.tracked() == MapSet.new([path_of_tmp_file])
+    assert File.exists?(path_of_tmp_file)
+
+    Temp.cleanup()
+
+    Task.start(fn ->
+      Temp.track!()
+      dir = Temp.mkdir!()
+      Temp.handoff(dir, heir_pid)
+      1 = 2
+    end)
+
+    :timer.sleep(50)
+    assert Temp.tracked() != MapSet.new()
+  end
+
+  test "automatically cleans up" do
+    dir = Temp.mkdir!()
+    assert File.exists?(dir)
+
+    normal_end =
+      Task.async(fn ->
+        Temp.track!()
+        Temp.track_file(dir)
+        :ok
+      end)
+
+    Task.await(normal_end)
+    :timer.sleep(50)
+    refute File.exists?(dir)
+  end
+
+  test "automatically cleans up after crashes" do
+    dir = Temp.mkdir!()
+    assert File.exists?(dir)
+
+    Task.start(fn ->
+      Temp.track!()
+      Temp.track_file(dir)
+      exit(:kill)
+      :ok
+    end)
+
+    :timer.sleep(50)
+    refute File.exists?(dir)
   end
 end

--- a/test/temp_test.exs
+++ b/test/temp_test.exs
@@ -156,7 +156,7 @@ defmodule TempTest do
       end)
       |> Task.await()
 
-    assert Temp.tracked() == MapSet.new([path_of_tmp_file])
+    assert Temp.tracked() == Temp.Tracker.set([path_of_tmp_file])
     assert File.exists?(path_of_tmp_file)
 
     Temp.cleanup()
@@ -169,7 +169,7 @@ defmodule TempTest do
     end)
 
     :timer.sleep(50)
-    refute Temp.tracked() == MapSet.new()
+    refute Temp.tracked() == Temp.Tracker.set()
     Temp.cleanup()
   end
 

--- a/test/temp_test.exs
+++ b/test/temp_test.exs
@@ -145,6 +145,7 @@ defmodule TempTest do
     Temp.mkdir!()
 
     heir_pid = Temp.track!()
+    assert Temp.tracked() == MapSet.new()
 
     path_of_tmp_file =
       Task.async(fn ->
@@ -168,7 +169,7 @@ defmodule TempTest do
     end)
 
     :timer.sleep(50)
-    assert Temp.tracked() != MapSet.new()
+    refute Temp.tracked() == MapSet.new()
   end
 
   test "automatically cleans up" do

--- a/test/temp_test.exs
+++ b/test/temp_test.exs
@@ -170,6 +170,7 @@ defmodule TempTest do
 
     :timer.sleep(50)
     refute Temp.tracked() == MapSet.new()
+    Temp.cleanup()
   end
 
   test "automatically cleans up" do


### PR DESCRIPTION
### Problem:
When stages of processing files involve reading and writing,  each stage can return a path(s) to save time. But as of right now, Temp would clean up the returned path(s) (assuming they were tracked), so returning them becomes useless.

### Solution
Implement a method, `handoff(paths, heir_pid)`, to pass tracking of path(s) to a tracker at `heir_pid`. This ensures that the paths will always be cleaned up if the process whose tracker is heir_pid dies.

### Extra tests
#### Tests testing existing functionality:
**"automatically cleans up"**
Make an untracked directory, then track it in a different process. Refute that the directory exists after awaiting the process than waiting for 50ms.
**"automatically cleans up after crashes"**
Same as "automatically cleans up", but the process crashes due to a match error.
#### Testing handoff
Assert that the tracker for the testing process is empty.
Make and track a directory in a separate process, then hand off the directory to the tracker for the testing process. 
Assert that the directory is tracked under the tracker for the testing process and that it still exists.
Cleanup the tracker
Do the same for a process that crashes, but only refute that the set of tracked directories is empty. We know for sure that the directory inside the set is the one made by the task we started with `Task.start`.