### PR TITLE
Fix compilation warnings on recent versions of Elixir

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/temp.ex
+++ b/lib/temp.ex
@@ -263,7 +263,7 @@ defmodule Temp do
     Integer.to_string(rand_uniform(0x100000000), 36) |> String.downcase
   end
 
-  if :erlang.system_info(:otp_release) >= '18' do
+  if :erlang.system_info(:otp_release) >= ~c"18" do
     defp rand_uniform(num) do
       :rand.uniform(num)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Temp.Mixfile do
     [
       app: :temp,
       version: @version,
-      elixir: "~> 1.0",
+      elixir: "~> 1.9",
       name: "temp",
       source_url: @source_url,
       homepage_url: @source_url,


### PR DESCRIPTION
I fixed all the compilation warnings on Elixir 1.16

Notes:
- `Config` was added in 1.9 (released 5 years ago) https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/
- sigil_c was added pre-1.0

The warnings were:
```
> mix compile --warnings-as-errors
    warning: use Mix.Config is deprecated. Use the Config module instead
    │
  3 │ use Mix.Config
    │ ~~~~~~~~~~~~~~
    │
    └─ config/config.exs:3

Compiling 3 files (.ex)
     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 266 │   if :erlang.system_info(:otp_release) >= '18' do
     │                                           ~
     │
     └─ lib/temp.ex:266:43
```